### PR TITLE
Resolve #5

### DIFF
--- a/skafka/templates/ui4kafka/configmap_fromValues.yaml
+++ b/skafka/templates/ui4kafka/configmap_fromValues.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.ui4kafka.myYamlApplicationConfig -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skafka-ui-config
+  labels:
+    {{- include "skafka.labels" . | nindent 4 }}
+data:
+  myconfig.yml: |-
+    {{- tpl (toYaml .Values.ui4kafka.myYamlApplicationConfig) $ | nindent 4}}
+{{ end }}

--- a/skafka/values.yaml
+++ b/skafka/values.yaml
@@ -179,24 +179,29 @@ ui4kafka:
   enabled: true
   image:  # 글로벌 적용 불가
     registry: docker.io
-  yamlApplicationConfig:
+  yamlApplicationConfig: false  # warning 메시지 발생하지만 괜찮음. # 아래서 Helm 내장객체인 {{ .Release.Name }} 사용하려면 false 설정필요
+  myYamlApplicationConfig:
     kafka:
       clusters:
-        # - name: ReleaseName-kafka
-        #   bootstrapServers: ReleaseName-kafka-headless:9092
-        #   zookeeper: ReleaseName-zookeeper-headless:2181
-        #   kafkaConnect:
-        #     - name: connect                              # kafka_connect.connects에서 정의한 이름을 기술
-        #       address: http://ReleaseName-kafka-connect:8083
-        #   metrics:
-        #     port: 5556
-        #     type: JMX
+        - name: "{{ .Release.Name }}-kafka"
+          bootstrapServers: "{{ .Release.Name }}-kafka:9092"
+          # zookeeper: ReleaseName-zookeeper-headless:2181
+          kafkaConnect:
+            - name: connect
+              address: http://{{ .Release.Name }}-connect:8083
+          # metrics:
+          #   port: 5556
+          #   type: JMX
     auth:
       type: disabled
     management:
       health:
         ldap:
           enabled: false
+  yamlApplicationConfigConfigMap:
+    keyName: myconfig.yml
+    name: skafka-ui-config  # configMapName
+      
   tolerations:
     - key: type
       operator: "Equal"

--- a/values/new_testbed.yaml
+++ b/values/new_testbed.yaml
@@ -133,7 +133,7 @@ kafka:
 
 
 connect:
-  enabled: false
+  enabled: true
   replicaCount: 1
   image:
     repository: confluentinc/cp-kafka-connect  # registry 포함 표기 가능. 없으면 container runtime의 default
@@ -181,34 +181,10 @@ k8dashboard:
     value: "ctrl"
     effect: "NoSchedule"
 
-
 ui4kafka:
   enabled: true
   image:  # 글로벌 적용 불가
     registry: docker.io
-  yamlApplicationConfig:
-    kafka:
-      clusters:
-        - name: testbed-kafka
-          bootstrapServers: "testbed-kafka:9092"
-          # zookeeper: ReleaseName-zookeeper-headless:2181
-          kafkaConnect:
-            - name: connect
-              address: http://testbed-connect:8083
-          # metrics:
-          #   port: 5556
-          #   type: JMX
-    auth:
-      type: disabled
-    management:
-      health:
-        ldap:
-          enabled: false
-  tolerations:
-    - key: type
-      operator: "Equal"
-      value: "ctrl"
-      effect: "NoSchedule"
 
 ingress:
   enabled: true


### PR DESCRIPTION
- Kafka-UI에서  Helm 내장객체인 {{ .Release.Name }} 을 value파일에서 사용할 수 있도록 수정.
- golang의 tpl함수로 간단히 구현가능하지만 이는 하위차트 수정이 필요한 부분임.
- 하위차트 수정시 관리가 번거로워 지므로 상위차트에서 최대한 해결하는 것이 목표였음.
- 수정없이 상위차트의 configmap을 만들고, 상위 value를 일부 수정함.